### PR TITLE
Added CLICKHOUSE_SKIP_USER_SETUP=1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An action that runs ClickHouse on the default ports in GitHub Actions.
 Just use it in your GitHub actions Yaml file like this:
 ```yaml
     steps:
-      - uses: ryanldy/action-clickhouse-in-ci@v1.0.0
+      - uses: ryanldy/action-clickhouse-in-ci@v1.0
 ```
 
 ## Note

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An action that runs ClickHouse on the default ports in GitHub Actions.
 Just use it in your GitHub actions Yaml file like this:
 ```yaml
     steps:
-      - uses: ryanldy/action-clickhouse-in-ci@v1.0
+      - uses: getsentry/action-clickhouse-in-ci@v1.1
 ```
 
 ## Note

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An action that runs ClickHouse on the default ports in GitHub Actions.
 Just use it in your GitHub actions Yaml file like this:
 ```yaml
     steps:
-      - uses: ryanldy/action-clickhouse-in-ci@v1.1
+      - uses: ryanldy/action-clickhouse-in-ci@v1.0.0
 ```
 
 ## Note

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An action that runs ClickHouse on the default ports in GitHub Actions.
 Just use it in your GitHub actions Yaml file like this:
 ```yaml
     steps:
-      - uses: getsentry/action-clickhouse-in-ci@v1.1
+      - uses: ryanldy/action-clickhouse-in-ci@v1.1
 ```
 
 ## Note

--- a/run-clickhouse.sh
+++ b/run-clickhouse.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-docker run -d -p 8123:8123 -p 9000:9000 --name clickhouse-test --ulimit nofile=262144:262144 --rm clickhouse
+docker run -d -p 8123:8123 -p 9000:9000 --name clickhouse-test --ulimit nofile=262144:262144 -e CLICKHOUSE_SKIP_USER_SETUP=1 --rm clickhouse


### PR DESCRIPTION
From https://hub.docker.com/_/clickhouse: 

The user default has disabled network access by default in the case none of CLICKHOUSE_USER, CLICKHOUSE_PASSWORD, or CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT are set.

There's a way to make default user insecurely available by setting environment variable CLICKHOUSE_SKIP_USER_SETUP to 1.

cc: @antonpirker 